### PR TITLE
added the ability for the mapper function to return an array of key v…

### DIFF
--- a/src/arrayToObject.js
+++ b/src/arrayToObject.js
@@ -28,7 +28,20 @@ function arrayToObject(input, val) {
   }
 
   return input.reduce(function(container, value, key) {
-    container[value] = val ? val(value, key, input) : defaultValue;
+    var _key = value, _value = defaultValue;
+
+    if (val) {
+      var result = val(value, key, input);
+      if (types.isArray(result)) {
+        _key = result[0];
+        _value = result[1];
+      }
+      else {
+        _value = result;
+      }
+    }
+
+    container[_key] = _value;
     return container;
   }, {});
 }

--- a/test/spec/arrayToObject.js
+++ b/test/spec/arrayToObject.js
@@ -35,7 +35,7 @@ describe("arrayToObject suite", function() {
       });
     });
 
-    describe("with custom of a function", function() {
+    describe("with custom of a function that returns the values to be used in the map", function() {
       var stub, input, result;
 
       beforeEach(function() {
@@ -62,5 +62,34 @@ describe("arrayToObject suite", function() {
         });
       });
     });
+
+    describe("with custom of a function that returns the keys and values to be used in the map", function() {
+      var stub, input, result;
+
+      beforeEach(function() {
+        stub = sinon.stub();
+        stub.withArgs(1).returns([43, "good"]);
+        stub.withArgs(3.2).returns([199, "another hit"]);
+
+        input = [1, 3.2];
+        result = arrayToObject(input, stub);
+      });
+
+      it("then the function for handling the first item is called", function() {
+        sinon.assert.calledWith(stub, 1, 0, input);
+      });
+
+      it("then the function for handling the second item is called", function() {
+        sinon.assert.calledWith(stub, 3.2, 1, input);
+      });
+
+      it("then the result contains the results from calling the function", function() {
+        expect(result).to.deep.equal({
+          "43": "good",
+          "199": "another hit"
+        });
+      });
+    });
+
   });
 });


### PR DESCRIPTION
…alue entires to build the map with custom keys and values

The following example will generate a map with keys that are `value * 2` and the mapped value is just the value itself.
```
arrayToMap([1, 2, 3], (value) => [value * 2, value])
```